### PR TITLE
Issue14/feat/spilit view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Task, ViewMode } from './types';
+import { Task, ViewMode, SplitViewConfig } from './types';
 import { TaskForm } from './components/TaskForm';
 import { TaskList } from './components/TaskList';
 import { GanttChart } from './components/GanttChart';
@@ -15,12 +15,20 @@ import {
   CloseIcon,
   iconSizes
 } from './components/icons';
+import { ResizablePanel } from './components/ResizablePanel';
 import './styles/globals.css';
 
 const App: React.FC = () => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [yamlString, setYamlString] = useState<string>('');
   const [currentView, setCurrentView] = useState<ViewMode>('list');
+  const [splitViewConfig, setSplitViewConfig] = useState<SplitViewConfig>({
+    leftPane: 'list',
+    rightPane: 'gantt',
+    splitDirection: 'horizontal',
+    leftSize: 50,
+    rightSize: 50
+  });
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -31,6 +39,18 @@ const App: React.FC = () => {
     const storedYaml = localStorage.getItem('tasksYaml');
     const initialYaml = storedYaml || INITIAL_TASKS_YAML;
     setYamlString(initialYaml);
+    
+    // Load split view configuration from localStorage
+    const storedSplitConfig = localStorage.getItem('splitViewConfig');
+    if (storedSplitConfig) {
+      try {
+        const parsedConfig = JSON.parse(storedSplitConfig);
+        setSplitViewConfig(parsedConfig);
+      } catch (e) {
+        console.error('Failed to parse stored split view config:', e);
+      }
+    }
+    
     try {
       const parsedTasks = parseTasksFromYaml(initialYaml);
       setTasks(parsedTasks);
@@ -140,8 +160,8 @@ const App: React.FC = () => {
     setIsModalOpen(true);
   };
 
-  const renderView = () => {
-    switch (currentView) {
+  const renderSingleView = (viewType: 'list' | 'gantt' | 'ai', isInSplitView: boolean = false) => {
+    switch (viewType) {
       case 'list':
         return <TaskList tasks={tasks} onEditTask={handleEditTask} onDeleteTask={handleDeleteTask} onBulkUpdate={handleBulkUpdate} onReorderTasks={handleReorderTasks} />;
       case 'gantt':
@@ -162,12 +182,73 @@ const App: React.FC = () => {
     }
   };
 
+  const renderSplitView = () => {
+    let leftPane: 'list' | 'gantt' | 'ai' = 'list';
+    let rightPane: 'list' | 'gantt' | 'ai' = 'gantt';
+
+    switch (currentView) {
+      case 'split-list-gantt':
+        leftPane = 'list';
+        rightPane = 'gantt';
+        break;
+      case 'split-list-ai':
+        leftPane = 'list';
+        rightPane = 'ai';
+        break;
+      case 'split-gantt-ai':
+        leftPane = 'gantt';
+        rightPane = 'ai';
+        break;
+    }
+
+    return (
+      <div className="flex h-full gap-2">
+        <ResizablePanel
+          direction="horizontal"
+          initialSize={splitViewConfig.leftSize}
+          onResize={(newSize) => {
+            const newConfig = { ...splitViewConfig, leftSize: newSize, rightSize: 100 - newSize };
+            setSplitViewConfig(newConfig);
+            localStorage.setItem('splitViewConfig', JSON.stringify(newConfig));
+          }}
+          className="flex-shrink-0"
+        >
+          <div className="h-full overflow-hidden bg-slate-800/40 backdrop-blur-sm rounded-lg shadow-lg border border-slate-700/50 p-4">
+            {renderSingleView(leftPane, true)}
+          </div>
+        </ResizablePanel>
+        
+        <div className="flex-1 overflow-hidden bg-slate-800/40 backdrop-blur-sm rounded-lg shadow-lg border border-slate-700/50 p-4">
+          {renderSingleView(rightPane, true)}
+        </div>
+      </div>
+    );
+  };
+
+  const renderView = () => {
+    // Force single view on mobile for split views
+    if (currentView.startsWith('split-')) {
+      const isMobile = window.innerWidth < 768;
+      if (isMobile) {
+        // Default to first view on mobile
+        let fallbackView: 'list' | 'gantt' | 'ai' = 'list';
+        if (currentView === 'split-list-gantt') fallbackView = 'list';
+        else if (currentView === 'split-list-ai') fallbackView = 'list';
+        else if (currentView === 'split-gantt-ai') fallbackView = 'gantt';
+        return renderSingleView(fallbackView);
+      }
+      return renderSplitView();
+    }
+    return renderSingleView(currentView as 'list' | 'gantt' | 'ai');
+  };
+
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-br from-slate-900 via-slate-900 to-slate-950 text-slate-100">
       <header className="bg-slate-800/60 backdrop-blur-md shadow-xl border-b border-slate-700/50 p-3 md:p-4 sticky top-0 z-40">
         <div className="w-full max-w-none px-4 md:px-8 flex flex-col sm:flex-row justify-between items-center">
           <h1 className="text-3xl font-bold text-sky-400 tracking-tight drop-shadow-md">{APP_TITLE}</h1>
-          <nav className="mt-2 sm:mt-0 flex space-x-2 sm:space-x-3">
+          <nav className="mt-2 sm:mt-0 flex flex-wrap gap-2 sm:gap-3">
+            {/* Single View Buttons */}
             {(['list', 'gantt', 'ai'] as ViewMode[]).map(view => {
               const getViewIcon = (viewType: ViewMode) => {
                 switch (viewType) {
@@ -191,6 +272,43 @@ const App: React.FC = () => {
                 </button>
               );
             })}
+
+            {/* Split View Buttons - Hidden on mobile */}
+            <div className="hidden sm:flex items-center gap-1 ml-2 pl-2 border-l border-slate-600">
+              <button
+                onClick={() => setCurrentView('split-list-gantt')}
+                className={`flex items-center gap-1 px-2 py-2 text-xs font-medium rounded-md transition-all duration-200
+                  ${currentView === 'split-list-gantt'
+                    ? 'bg-emerald-600 text-white shadow-lg shadow-emerald-600/25 ring-1 ring-emerald-500/50'
+                    : 'text-slate-300 hover:bg-slate-700/70 hover:text-white hover:shadow-md'}`}
+              >
+                <ListViewIcon className="w-3 h-3" />
+                <span className="text-slate-400">|</span>
+                <GanttViewIcon className="w-3 h-3" />
+              </button>
+              <button
+                onClick={() => setCurrentView('split-list-ai')}
+                className={`flex items-center gap-1 px-2 py-2 text-xs font-medium rounded-md transition-all duration-200
+                  ${currentView === 'split-list-ai'
+                    ? 'bg-emerald-600 text-white shadow-lg shadow-emerald-600/25 ring-1 ring-emerald-500/50'
+                    : 'text-slate-300 hover:bg-slate-700/70 hover:text-white hover:shadow-md'}`}
+              >
+                <ListViewIcon className="w-3 h-3" />
+                <span className="text-slate-400">|</span>
+                <AiViewIcon className="w-3 h-3" />
+              </button>
+              <button
+                onClick={() => setCurrentView('split-gantt-ai')}
+                className={`flex items-center gap-1 px-2 py-2 text-xs font-medium rounded-md transition-all duration-200
+                  ${currentView === 'split-gantt-ai'
+                    ? 'bg-emerald-600 text-white shadow-lg shadow-emerald-600/25 ring-1 ring-emerald-500/50'
+                    : 'text-slate-300 hover:bg-slate-700/70 hover:text-white hover:shadow-md'}`}
+              >
+                <GanttViewIcon className="w-3 h-3" />
+                <span className="text-slate-400">|</span>
+                <AiViewIcon className="w-3 h-3" />
+              </button>
+            </div>
           </nav>
         </div>
       </header>
@@ -225,7 +343,7 @@ const App: React.FC = () => {
           </div>
         )}
 
-        {currentView === 'list' && (
+        {(currentView === 'list' || currentView.includes('list')) && (
           <div className="mb-6 flex justify-end">
             <button
               onClick={openNewTaskModal}
@@ -237,8 +355,7 @@ const App: React.FC = () => {
           </div>
         )}
         
-        <div className={`bg-slate-800/40 backdrop-blur-sm rounded-xl shadow-2xl border border-slate-700/50 min-h-[70vh] ${currentView === 'list' ? 'p-3 sm:p-5' : 'p-4 sm:p-6'}`}>
-        {/* h-[80vh] overflow-y-auto */}
+        <div className={`${currentView.startsWith('split-') ? 'min-h-[70vh]' : 'bg-slate-800/40 backdrop-blur-sm rounded-xl shadow-2xl border border-slate-700/50 min-h-[70vh]'} ${currentView === 'list' ? 'p-3 sm:p-5' : currentView.startsWith('split-') ? '' : 'p-4 sm:p-6'}`}>
             {renderView()}
         </div>
       </main>

--- a/App.tsx
+++ b/App.tsx
@@ -163,9 +163,9 @@ const App: React.FC = () => {
   const renderSingleView = (viewType: 'list' | 'gantt' | 'ai', isInSplitView: boolean = false) => {
     switch (viewType) {
       case 'list':
-        return <TaskList tasks={tasks} onEditTask={handleEditTask} onDeleteTask={handleDeleteTask} onBulkUpdate={handleBulkUpdate} onReorderTasks={handleReorderTasks} />;
+        return <TaskList tasks={tasks} onEditTask={handleEditTask} onDeleteTask={handleDeleteTask} onBulkUpdate={handleBulkUpdate} onReorderTasks={handleReorderTasks} isInSplitView={isInSplitView} />;
       case 'gantt':
-        return <GanttChart tasks={tasks} onEditTask={handleEditTask} onTaskDateChange={handleTaskDateChange} onMultipleTaskDateChange={handleMultipleTaskDateChange} />;
+        return <GanttChart tasks={tasks} onEditTask={handleEditTask} onTaskDateChange={handleTaskDateChange} onMultipleTaskDateChange={handleMultipleTaskDateChange} isInSplitView={isInSplitView} />;
       case 'ai':
         return (
           <AiInteraction
@@ -175,6 +175,7 @@ const App: React.FC = () => {
             isLoading={isLoading}
             setIsLoading={setIsLoading}
             setError={setError}
+            isInSplitView={isInSplitView}
           />
         );
       default:
@@ -202,7 +203,7 @@ const App: React.FC = () => {
     }
 
     return (
-      <div className="flex h-full gap-2">
+      <div className="flex h-full gap-2 overflow-hidden">
         <ResizablePanel
           direction="horizontal"
           initialSize={splitViewConfig.leftSize}
@@ -243,8 +244,8 @@ const App: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-br from-slate-900 via-slate-900 to-slate-950 text-slate-100">
-      <header className="bg-slate-800/60 backdrop-blur-md shadow-xl border-b border-slate-700/50 p-3 md:p-4 sticky top-0 z-40">
+    <div className="h-screen flex flex-col bg-gradient-to-br from-slate-900 via-slate-900 to-slate-950 text-slate-100 overflow-hidden">
+      <header className="bg-slate-800/60 backdrop-blur-md shadow-xl border-b border-slate-700/50 p-3 md:p-4 flex-shrink-0 z-40">
         <div className="w-full max-w-none px-4 md:px-8 flex flex-col sm:flex-row justify-between items-center">
           <h1 className="text-3xl font-bold text-sky-400 tracking-tight drop-shadow-md">{APP_TITLE}</h1>
           <nav className="mt-2 sm:mt-0 flex flex-wrap gap-2 sm:gap-3">
@@ -313,7 +314,7 @@ const App: React.FC = () => {
         </div>
       </header>
 
-      <main className="w-full px-4 md:px-8 pt-4 md:pt-6 flex-grow">
+      <main className="w-full px-4 md:px-8 pt-4 md:pt-6 flex-1 flex flex-col overflow-hidden">
         {error && (
           <div className="mb-4 p-4 bg-red-500/20 border border-red-400/50 text-red-200 rounded-lg shadow-lg" role="alert">
             <div className="flex items-start justify-between">
@@ -344,7 +345,7 @@ const App: React.FC = () => {
         )}
 
         {(currentView === 'list' || currentView.includes('list')) && (
-          <div className="mb-6 flex justify-end">
+          <div className="mb-6 flex justify-end flex-shrink-0">
             <button
               onClick={openNewTaskModal}
               className="flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:ring-green-500 transition-all hover:scale-105 border border-green-500/30"
@@ -355,7 +356,7 @@ const App: React.FC = () => {
           </div>
         )}
         
-        <div className={`${currentView.startsWith('split-') ? 'min-h-[70vh]' : 'bg-slate-800/40 backdrop-blur-sm rounded-xl shadow-2xl border border-slate-700/50 min-h-[70vh]'} ${currentView === 'list' ? 'p-3 sm:p-5' : currentView.startsWith('split-') ? '' : 'p-4 sm:p-6'}`}>
+        <div className={`${currentView.startsWith('split-') ? 'flex-1 overflow-hidden' : 'bg-slate-800/40 backdrop-blur-sm rounded-xl shadow-2xl border border-slate-700/50 flex-1 overflow-auto'} ${currentView === 'list' ? 'p-3 sm:p-5' : currentView.startsWith('split-') ? '' : 'p-4 sm:p-6'}`}>
             {renderView()}
         </div>
       </main>

--- a/components/AiInteraction.tsx
+++ b/components/AiInteraction.tsx
@@ -10,6 +10,7 @@ interface AiInteractionProps {
   isLoading: boolean;
   setIsLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
+  isInSplitView?: boolean;
 }
 
 export const AiInteraction: React.FC<AiInteractionProps> = ({
@@ -18,7 +19,8 @@ export const AiInteraction: React.FC<AiInteractionProps> = ({
   onYamlUpdateByAi,
   isLoading,
   setIsLoading,
-  setError
+  setError,
+  isInSplitView = false
 }) => {
   const [aiSummary, setAiSummary] = useState<string>('');
   const [userPrompt, setUserPrompt] = useState<string>('');
@@ -86,68 +88,74 @@ export const AiInteraction: React.FC<AiInteractionProps> = ({
     }
   };
 
+  const yamlRows = isInSplitView ? 10 : 15;
+  
   return (
-    <div className="space-y-6 p-1">
-      <div>
-        <h3 className="text-xl font-semibold text-sky-400 mb-2">AI Task Summary</h3>
-        <button
-          onClick={fetchSummary}
-          disabled={isLoading}
-          className="mb-2 px-4 py-2 text-sm font-medium text-white bg-sky-600 hover:bg-sky-700 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:ring-sky-500 disabled:opacity-50"
-        >
-          {isLoading && aiSummary === '' ? 'Generating Summary...' : 'Get AI Summary'}
-        </button>
-        {aiSummary && (
-          <div className="bg-slate-800 p-4 rounded-md shadow">
-            <pre className="whitespace-pre-wrap text-sm text-slate-300">{aiSummary}</pre>
-          </div>
-        )}
-      </div>
+    <div className={`${isInSplitView ? 'h-full overflow-hidden' : ''} flex flex-col`}>
+      <div className={`${isInSplitView ? 'flex-1 overflow-auto' : ''} space-y-6 p-1`}>
+        <div>
+          <h3 className="text-xl font-semibold text-sky-400 mb-2">AI Task Summary</h3>
+          <button
+            onClick={fetchSummary}
+            disabled={isLoading}
+            className="mb-2 px-4 py-2 text-sm font-medium text-white bg-sky-600 hover:bg-sky-700 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:ring-sky-500 disabled:opacity-50"
+          >
+            {isLoading && aiSummary === '' ? 'Generating Summary...' : 'Get AI Summary'}
+          </button>
+          {aiSummary && (
+            <div className="bg-slate-800 p-4 rounded-md shadow">
+              <pre className="whitespace-pre-wrap text-sm text-slate-300">{aiSummary}</pre>
+            </div>
+          )}
+        </div>
 
-      <div>
-        <h3 className="text-xl font-semibold text-sky-400 mb-2">Manage Tasks with AI (via YAML)</h3>
-        <form onSubmit={handlePromptSubmit} className="space-y-3">
-          <div>
-            <label htmlFor="ai-prompt" className="block text-sm font-medium text-slate-300">
-              Enter command (e.g., "Add a new task 'Deploy App' due next Friday with high priority")
-            </label>
+        <div>
+          <h3 className="text-xl font-semibold text-sky-400 mb-2">Manage Tasks with AI (via YAML)</h3>
+          <form onSubmit={handlePromptSubmit} className="space-y-3">
+            <div>
+              <label htmlFor="ai-prompt" className="block text-sm font-medium text-slate-300">
+                Enter command (e.g., "Add a new task 'Deploy App' due next Friday with high priority")
+              </label>
+              <textarea
+                id="ai-prompt"
+                value={userPrompt}
+                onChange={(e) => setUserPrompt(e.target.value)}
+                rows={3}
+                className="mt-1 block w-full bg-slate-700 border-slate-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-sky-500 focus:border-sky-500 sm:text-sm text-slate-100 disabled:opacity-60"
+                placeholder="Describe changes to tasks..."
+                disabled={isLoading}
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:ring-green-500 disabled:opacity-50"
+            >
+              {isLoading ? 'Processing...' : 'Update Tasks with AI'}
+            </button>
+          </form>
+        </div>
+
+        <div>
+          <h3 className="text-xl font-semibold text-sky-400 mb-2">Current Tasks (YAML) - Edit or Paste Here</h3>
+          <div className={`${isInSplitView ? 'flex-1' : ''}`}>
             <textarea
-              id="ai-prompt"
-              value={userPrompt}
-              onChange={(e) => setUserPrompt(e.target.value)}
-              rows={3}
-              className="mt-1 block w-full bg-slate-700 border-slate-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-sky-500 focus:border-sky-500 sm:text-sm text-slate-100 disabled:opacity-60"
-              placeholder="Describe changes to tasks..."
+              value={editableYaml}
+              onChange={(e) => setEditableYaml(e.target.value)}
+              rows={yamlRows}
+              className="w-full bg-slate-700 border-slate-600 text-slate-100 p-3 text-xs rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500"
+              aria-label="Current tasks in YAML format, editable"
               disabled={isLoading}
             />
+            <button
+              onClick={handleDirectYamlSubmit}
+              disabled={isLoading}
+              className="mt-2 px-4 py-2 text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:ring-purple-500 disabled:opacity-50"
+            >
+              {isLoading ? 'Applying YAML...' : 'Apply YAML Changes'}
+            </button>
           </div>
-          <button
-            type="submit"
-            disabled={isLoading}
-            className="px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:ring-green-500 disabled:opacity-50"
-          >
-            {isLoading ? 'Processing...' : 'Update Tasks with AI'}
-          </button>
-        </form>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold text-sky-400 mb-2">Current Tasks (YAML) - Edit or Paste Here</h3>
-        <textarea
-          value={editableYaml}
-          onChange={(e) => setEditableYaml(e.target.value)}
-          rows={15}
-          className="w-full bg-slate-700 border-slate-600 text-slate-100 p-3 text-xs rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500"
-          aria-label="Current tasks in YAML format, editable"
-          disabled={isLoading}
-        />
-        <button
-          onClick={handleDirectYamlSubmit}
-          disabled={isLoading}
-          className="mt-2 px-4 py-2 text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:ring-purple-500 disabled:opacity-50"
-        >
-          {isLoading ? 'Applying YAML...' : 'Apply YAML Changes'}
-        </button>
+        </div>
       </div>
     </div>
   );

--- a/components/GanttChart.tsx
+++ b/components/GanttChart.tsx
@@ -16,6 +16,7 @@ interface GanttChartProps {
   onEditTask: (task: Task) => void;
   onTaskDateChange?: (taskId: string, newStartDate: string, newEndDate: string) => void;
   onMultipleTaskDateChange?: (taskUpdates: Array<{taskId: string, newStartDate: string, newEndDate: string}>) => void;
+  isInSplitView?: boolean;
 }
 
 // const DAY_WIDTH = 30; // pixels per day // This seems unused, unitWidth is used instead
@@ -32,7 +33,7 @@ interface TooltipData {
   y: number;
 }
 
-export const GanttChart: React.FC<GanttChartProps> = ({ tasks, onEditTask, onTaskDateChange, onMultipleTaskDateChange }) => {
+export const GanttChart: React.FC<GanttChartProps> = ({ tasks, onEditTask, onTaskDateChange, onMultipleTaskDateChange, isInSplitView = false }) => {
   const [labelWidth, setLabelWidth] = useState(150); // 初期値を150に設定
   const [isResizing, setIsResizing] = useState(false);
   const [tooltipData, setTooltipData] = useState<TooltipData | null>(null); // ツールチップ用state
@@ -531,8 +532,8 @@ export const GanttChart: React.FC<GanttChartProps> = ({ tasks, onEditTask, onTas
   };
 
   return (
-    <div className="bg-slate-800 p-4 rounded-lg shadow-lg relative" ref={chartContainerRef}>
-      <div className="flex justify-between items-center mb-4">
+    <div className={`bg-slate-800 p-4 rounded-lg shadow-lg relative ${isInSplitView ? 'h-full flex flex-col' : ''}`} ref={chartContainerRef}>
+      <div className={`flex justify-between items-center mb-4 ${isInSplitView ? 'flex-shrink-0' : ''}`}>
         <h3 className="text-xl font-semibold text-sky-400">Gantt Chart</h3>
         <div className="flex items-center space-x-4">
           {/* Multi-select Mode Controls */}
@@ -642,7 +643,7 @@ export const GanttChart: React.FC<GanttChartProps> = ({ tasks, onEditTask, onTas
           </div>
         </div>
       </div>
-      <div className="overflow-auto" style={{ height: '75vh' }}>
+      <div className={`overflow-auto ${isInSplitView ? 'flex-1' : ''}`} style={{ height: isInSplitView ? undefined : '75vh' }}>
         <div style={{ width: totalUnits * unitWidth + labelWidth + 8, minHeight: (tasks.length + 2) * rowHeight + CHART_PADDING*2 }} className={`relative ${isMultiSelectMode ? 'bg-purple-900/10' : ''}`}>
           {/* Multi-select mode indicator */}
           {isMultiSelectMode && (

--- a/components/ResizablePanel.tsx
+++ b/components/ResizablePanel.tsx
@@ -1,0 +1,118 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+interface ResizablePanelProps {
+  children: React.ReactNode;
+  direction: 'horizontal' | 'vertical';
+  initialSize: number; // Percentage (0-100)
+  minSize?: number; // Minimum size in pixels
+  maxSize?: number; // Maximum size in pixels
+  onResize?: (newSize: number) => void;
+  className?: string;
+}
+
+export const ResizablePanel: React.FC<ResizablePanelProps> = ({
+  children,
+  direction,
+  initialSize,
+  minSize = 300,
+  maxSize = 80,
+  onResize,
+  className = ''
+}) => {
+  const [size, setSize] = useState(initialSize);
+  const [isDragging, setIsDragging] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const startPos = useRef(0);
+  const startSize = useRef(0);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    setIsDragging(true);
+    startPos.current = direction === 'horizontal' ? e.clientX : e.clientY;
+    startSize.current = size;
+    
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = direction === 'horizontal' ? 'col-resize' : 'row-resize';
+  };
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (!isDragging || !containerRef.current) return;
+
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const containerSize = direction === 'horizontal' ? containerRect.width : containerRect.height;
+    const currentPos = direction === 'horizontal' ? e.clientX : e.clientY;
+    const delta = currentPos - startPos.current;
+    const deltaPercentage = (delta / containerSize) * 100;
+    
+    let newSize = startSize.current + deltaPercentage;
+    
+    // Apply constraints
+    const minSizePercentage = (minSize / containerSize) * 100;
+    const maxSizePercentage = maxSize;
+    
+    newSize = Math.max(minSizePercentage, Math.min(maxSizePercentage, newSize));
+    
+    setSize(newSize);
+    onResize?.(newSize);
+  };
+
+  const handleMouseUp = () => {
+    setIsDragging(false);
+    document.removeEventListener('mousemove', handleMouseMove);
+    document.removeEventListener('mouseup', handleMouseUp);
+    document.body.style.userSelect = '';
+    document.body.style.cursor = '';
+  };
+
+  useEffect(() => {
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+    };
+  }, []);
+
+  const panelStyle = {
+    [direction === 'horizontal' ? 'width' : 'height']: `${size}%`,
+    minWidth: direction === 'horizontal' ? `${minSize}px` : undefined,
+    minHeight: direction === 'vertical' ? `${minSize}px` : undefined,
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative ${className}`}
+      style={panelStyle}
+    >
+      {children}
+      
+      {/* Resize Handle */}
+      <div
+        className={`absolute bg-slate-600 hover:bg-slate-500 transition-colors duration-200 cursor-${direction === 'horizontal' ? 'col' : 'row'}-resize z-10
+          ${direction === 'horizontal' 
+            ? 'right-0 top-0 w-1 h-full hover:w-2' 
+            : 'bottom-0 left-0 w-full h-1 hover:h-2'
+          }
+          ${isDragging ? 'bg-sky-500' : ''}
+        `}
+        onMouseDown={handleMouseDown}
+        style={{
+          [direction === 'horizontal' ? 'right' : 'bottom']: '-2px',
+        }}
+      >
+        {/* Visual indicator */}
+        <div
+          className={`absolute bg-slate-400 rounded-full opacity-0 hover:opacity-100 transition-opacity duration-200
+            ${direction === 'horizontal' 
+              ? 'left-1/2 top-1/2 w-1 h-8 -translate-x-1/2 -translate-y-1/2' 
+              : 'left-1/2 top-1/2 w-8 h-1 -translate-x-1/2 -translate-y-1/2'
+            }
+            ${isDragging ? 'opacity-100 bg-sky-400' : ''}
+          `}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/__tests__/SplitViewIntegration.test.tsx
+++ b/src/__tests__/SplitViewIntegration.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import App from '../App';
+
+// Mock the Gemini service
+vi.mock('../services/geminiService', () => ({
+  getAiTaskSummary: vi.fn().mockResolvedValue('Test summary'),
+  updateTasksViaAi: vi.fn().mockResolvedValue('tasks:\n- id: 1\n  name: Test Task')
+}));
+
+// Mock the calendar service
+vi.mock('../services/calendarService', () => ({
+  exportToGoogleCalendar: vi.fn(),
+  exportMultipleTasksToGoogleCalendar: vi.fn()
+}));
+
+// Mock localStorage
+const mockLocalStorage = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+Object.defineProperty(window, 'localStorage', { value: mockLocalStorage });
+
+describe('Split View Integration Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocalStorage.getItem.mockReturnValue(null);
+  });
+
+  describe('View Mode Switching', () => {
+    it('should switch from single view to split view correctly', () => {
+      render(<App />);
+      
+      // Start with list view
+      const listButton = screen.getByRole('button', { name: /list view/i });
+      expect(listButton).toBeDefined();
+      
+      // Click split view button (List + Gantt)
+      const splitButton = screen.getByRole('button', { name: /list.*gantt/i });
+      if (splitButton) {
+        fireEvent.click(splitButton);
+        
+        // Check that we're now in split view mode
+        // The app should render both views in panels
+        expect(document.querySelector('.flex.h-full.gap-2')).toBeDefined();
+      }
+    });
+
+    it('should maintain scroll state when switching between views', () => {
+      render(<App />);
+      
+      // Test switching between different view modes
+      const listButton = screen.getByRole('button', { name: /list view/i });
+      const ganttButton = screen.getByRole('button', { name: /gantt view/i });
+      
+      // Switch to list view
+      fireEvent.click(listButton);
+      let container = document.querySelector('.flex-1.overflow-auto');
+      expect(container).toBeDefined();
+      
+      // Switch to gantt view
+      fireEvent.click(ganttButton);
+      container = document.querySelector('.overflow-auto');
+      expect(container).toBeDefined();
+    });
+
+    it('should handle split view combinations correctly', () => {
+      render(<App />);
+      
+      // Test all split view combinations
+      const splitButtons = [
+        /list.*gantt/i,
+        /list.*ai/i,
+        /gantt.*ai/i
+      ];
+      
+      splitButtons.forEach(pattern => {
+        const button = screen.queryByRole('button', { name: pattern });
+        if (button) {
+          fireEvent.click(button);
+          
+          // Check that split view layout is applied
+          const splitContainer = document.querySelector('.flex.h-full.gap-2');
+          expect(splitContainer).toBeDefined();
+          
+          // Check that both panels exist
+          const panels = document.querySelectorAll('.overflow-hidden.bg-slate-800');
+          expect(panels.length).toBe(2);
+        }
+      });
+    });
+  });
+
+  describe('Scroll Container Integration', () => {
+    it('should ensure proper scroll containers in single view mode', () => {
+      render(<App />);
+      
+      // Test list view
+      const listButton = screen.getByRole('button', { name: /list view/i });
+      fireEvent.click(listButton);
+      
+      let scrollContainer = document.querySelector('.flex-1.overflow-auto');
+      expect(scrollContainer).toBeDefined();
+      
+      // Test gantt view
+      const ganttButton = screen.getByRole('button', { name: /gantt view/i });
+      fireEvent.click(ganttButton);
+      
+      scrollContainer = document.querySelector('.overflow-auto');
+      expect(scrollContainer).toBeDefined();
+      
+      // Test AI view
+      const aiButton = screen.getByRole('button', { name: /ai view/i });
+      fireEvent.click(aiButton);
+      
+      scrollContainer = document.querySelector('.flex-1.overflow-auto');
+      expect(scrollContainer).toBeDefined();
+    });
+
+    it('should ensure proper scroll containers in split view mode', () => {
+      render(<App />);
+      
+      // Click split view button
+      const splitButton = screen.queryByRole('button', { name: /list.*gantt/i });
+      if (splitButton) {
+        fireEvent.click(splitButton);
+        
+        // Check that both panels have proper scroll containers
+        const scrollContainers = document.querySelectorAll('.overflow-hidden');
+        expect(scrollContainers.length).toBeGreaterThan(0);
+        
+        // Check that panels are properly structured
+        const panels = document.querySelectorAll('.bg-slate-800');
+        expect(panels.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('Responsive Behavior', () => {
+    it('should handle mobile view correctly', () => {
+      // Mock mobile viewport
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: 500,
+      });
+      
+      render(<App />);
+      
+      // Split view buttons should be hidden on mobile
+      const splitButtons = document.querySelectorAll('.hidden.sm\\:flex');
+      expect(splitButtons.length).toBeGreaterThan(0);
+    });
+
+    it('should maintain scroll functionality across responsive breakpoints', () => {
+      render(<App />);
+      
+      // Test different view modes
+      const viewButtons = [
+        { name: /list view/i, selector: '.flex-1.overflow-auto' },
+        { name: /gantt view/i, selector: '.overflow-auto' },
+        { name: /ai view/i, selector: '.flex-1.overflow-auto' }
+      ];
+      
+      viewButtons.forEach(({ name, selector }) => {
+        const button = screen.getByRole('button', { name });
+        fireEvent.click(button);
+        
+        const scrollContainer = document.querySelector(selector);
+        expect(scrollContainer).toBeDefined();
+      });
+    });
+  });
+
+  describe('Layout Constraints', () => {
+    it('should enforce proper height constraints', () => {
+      render(<App />);
+      
+      // Check main container height
+      const mainContainer = document.querySelector('.h-screen');
+      expect(mainContainer).toBeDefined();
+      
+      // Check overflow handling
+      const overflowContainer = document.querySelector('.overflow-hidden');
+      expect(overflowContainer).toBeDefined();
+    });
+
+    it('should maintain proper flex layout structure', () => {
+      render(<App />);
+      
+      // Check main layout structure
+      const flexContainer = document.querySelector('.flex.flex-col');
+      expect(flexContainer).toBeDefined();
+      
+      // Check main content area
+      const mainContent = document.querySelector('.flex-1.flex.flex-col');
+      expect(mainContent).toBeDefined();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle view switching errors gracefully', () => {
+      render(<App />);
+      
+      // Test rapid view switching
+      const listButton = screen.getByRole('button', { name: /list view/i });
+      const ganttButton = screen.getByRole('button', { name: /gantt view/i });
+      
+      // Rapid switching should not cause errors
+      fireEvent.click(listButton);
+      fireEvent.click(ganttButton);
+      fireEvent.click(listButton);
+      
+      // App should still be responsive
+      expect(screen.getByRole('button', { name: /list view/i })).toBeDefined();
+    });
+  });
+});

--- a/src/components/__tests__/ScrollBehavior.test.tsx
+++ b/src/components/__tests__/ScrollBehavior.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TaskList } from '../../../components/TaskList';
+import { AiInteraction } from '../../../components/AiInteraction';
+import { GanttChart } from '../../../components/GanttChart';
+import { Task, TaskStatus, TaskPriority } from '../../../types';
+
+// Mock data
+const mockTasks: Task[] = [
+  {
+    id: '1',
+    name: 'Task 1',
+    description: 'Description 1',
+    status: TaskStatus.NOT_STARTED,
+    priority: TaskPriority.HIGH,
+    startDate: '2024-01-01',
+    endDate: '2024-01-02',
+    dependencies: []
+  },
+  {
+    id: '2',
+    name: 'Task 2',
+    description: 'Description 2',
+    status: TaskStatus.IN_PROGRESS,
+    priority: TaskPriority.MEDIUM,
+    startDate: '2024-01-03',
+    endDate: '2024-01-04',
+    dependencies: ['1']
+  }
+];
+
+const mockProps = {
+  tasks: mockTasks,
+  onEditTask: vi.fn(),
+  onDeleteTask: vi.fn(),
+  onBulkUpdate: vi.fn(),
+  onReorderTasks: vi.fn(),
+};
+
+const mockAiProps = {
+  tasks: mockTasks,
+  currentYaml: 'tasks:\n- id: 1\n  name: Task 1',
+  onYamlUpdateByAi: vi.fn(),
+  isLoading: false,
+  setIsLoading: vi.fn(),
+  setError: vi.fn(),
+};
+
+const mockGanttProps = {
+  tasks: mockTasks,
+  onEditTask: vi.fn(),
+  onTaskDateChange: vi.fn(),
+  onMultipleTaskDateChange: vi.fn(),
+};
+
+describe('Scroll Behavior Tests', () => {
+  describe('TaskList Component', () => {
+    it('should render with normal scroll behavior when not in split view', () => {
+      render(<TaskList {...mockProps} isInSplitView={false} />);
+      
+      const container = screen.getByRole('generic');
+      expect(container).toBeDefined();
+      // Normal view should not have height restrictions
+      expect(container.className).not.toContain('h-full');
+      expect(container.className).not.toContain('overflow-hidden');
+    });
+
+    it('should render with split view scroll behavior when in split view', () => {
+      render(<TaskList {...mockProps} isInSplitView={true} />);
+      
+      const container = screen.getByRole('generic');
+      expect(container).toBeDefined();
+      // Split view should have height restrictions and scroll
+      expect(container.className).toContain('h-full');
+      expect(container.className).toContain('overflow-hidden');
+    });
+
+    it('should have scrollable task list area in split view', () => {
+      render(<TaskList {...mockProps} isInSplitView={true} />);
+      
+      // Check if task list area exists with proper scroll classes
+      const taskListContainer = document.querySelector('.flex-1.overflow-auto');
+      expect(taskListContainer).toBeDefined();
+    });
+  });
+
+  describe('AiInteraction Component', () => {
+    it('should render with normal behavior when not in split view', () => {
+      render(<AiInteraction {...mockAiProps} isInSplitView={false} />);
+      
+      const container = screen.getByRole('generic');
+      expect(container).toBeDefined();
+      // Normal view should not have height restrictions
+      expect(container.className).not.toContain('h-full');
+      expect(container.className).not.toContain('overflow-hidden');
+    });
+
+    it('should render with split view behavior when in split view', () => {
+      render(<AiInteraction {...mockAiProps} isInSplitView={true} />);
+      
+      const container = screen.getByRole('generic');
+      expect(container).toBeDefined();
+      // Split view should have height restrictions
+      expect(container.className).toContain('h-full');
+      expect(container.className).toContain('overflow-hidden');
+    });
+
+    it('should have scrollable content area in split view', () => {
+      render(<AiInteraction {...mockAiProps} isInSplitView={true} />);
+      
+      // Check if content area exists with proper scroll classes
+      const contentContainer = document.querySelector('.flex-1.overflow-auto');
+      expect(contentContainer).toBeDefined();
+    });
+  });
+
+  describe('GanttChart Component', () => {
+    it('should render with normal scroll behavior when not in split view', () => {
+      render(<GanttChart {...mockGanttProps} isInSplitView={false} />);
+      
+      // Check if chart container exists
+      const chartContainer = document.querySelector('.overflow-auto');
+      expect(chartContainer).toBeDefined();
+      
+      // Should use 75vh height in normal view
+      expect(chartContainer?.getAttribute('style')).toContain('75vh');
+    });
+
+    it('should render with split view scroll behavior when in split view', () => {
+      render(<GanttChart {...mockGanttProps} isInSplitView={true} />);
+      
+      // Check if chart container exists
+      const chartContainer = document.querySelector('.overflow-auto');
+      expect(chartContainer).toBeDefined();
+      
+      // Should use calc height in split view
+      expect(chartContainer?.getAttribute('style')).toContain('calc(100% - 60px)');
+    });
+
+    it('should maintain scroll functionality across view modes', () => {
+      const { rerender } = render(<GanttChart {...mockGanttProps} isInSplitView={false} />);
+      
+      let chartContainer = document.querySelector('.overflow-auto');
+      expect(chartContainer).toBeDefined();
+      expect(chartContainer?.getAttribute('style')).toContain('75vh');
+      
+      // Switch to split view
+      rerender(<GanttChart {...mockGanttProps} isInSplitView={true} />);
+      
+      chartContainer = document.querySelector('.overflow-auto');
+      expect(chartContainer).toBeDefined();
+      expect(chartContainer?.getAttribute('style')).toContain('calc(100% - 60px)');
+    });
+  });
+
+  describe('Scroll Container Behavior', () => {
+    it('should ensure all components have proper scroll containers', () => {
+      // Test TaskList
+      const { unmount: unmountTaskList } = render(<TaskList {...mockProps} isInSplitView={true} />);
+      let scrollContainer = document.querySelector('.overflow-auto');
+      expect(scrollContainer).toBeDefined();
+      unmountTaskList();
+
+      // Test AiInteraction
+      const { unmount: unmountAi } = render(<AiInteraction {...mockAiProps} isInSplitView={true} />);
+      scrollContainer = document.querySelector('.overflow-auto');
+      expect(scrollContainer).toBeDefined();
+      unmountAi();
+
+      // Test GanttChart
+      render(<GanttChart {...mockGanttProps} isInSplitView={true} />);
+      scrollContainer = document.querySelector('.overflow-auto');
+      expect(scrollContainer).toBeDefined();
+    });
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -22,7 +22,15 @@ export interface Task {
   dependencies: string[]; // Array of task IDs this task depends on
 }
 
-export type ViewMode = 'list' | 'gantt' | 'ai';
+export type ViewMode = 'list' | 'gantt' | 'ai' | 'split-list-gantt' | 'split-list-ai' | 'split-gantt-ai';
+
+export interface SplitViewConfig {
+  leftPane: 'list' | 'gantt' | 'ai';
+  rightPane: 'list' | 'gantt' | 'ai';
+  splitDirection: 'horizontal' | 'vertical';
+  leftSize: number; // Percentage (0-100)
+  rightSize: number; // Percentage (0-100)
+}
 
 // For Gemini Search Grounding (if used)
 export interface WebGroundingChunk {


### PR DESCRIPTION
このプルリクエストでは、アプリケーションにスプリットビュー機能を導入し、ユーザーが複数のパネルを同時に表示・操作できるようになりました。また、`TaskList`、`GanttChart`、`AiInteraction` 各コンポーネントもスプリットビューに対応するようアップデートされ、新たに再利用可能な `ResizablePanel` コンポーネントも追加されています。主な変更点をテーマごとにまとめます。

### スプリットビュー機能
* `App.tsx` で `splitViewConfig` のステート管理を追加し、ユーザーがスプリットビューのレイアウトを設定できるようになりました。
* `renderSplitView` の実装と `renderView` の更新により、`split-list-gantt`、`split-list-ai`、`split-gantt-ai` などのスプリットビューモードやモバイル端末向けのフォールバック挙動に対応しました。
* ナビゲーションバーにスプリットビューモードの切り替えボタンを追加（モバイルでは非表示）。

### 各コンポーネントのスプリットビュー対応
* `TaskList`、`GanttChart`、`AiInteraction` 各コンポーネントが `isInSplitView` プロップを受け取り、スプリットビューモード時のレイアウト調整が可能になりました。
* スプリットビュー時には、これらのコンポーネントのレイアウトや挙動（例：動的リサイズ、YAMLテキストエリアの行数など）が調整されます。

### リサイズ可能なパネルコンポーネント
* 新たに `ResizablePanel` コンポーネントを追加し、スプリットビューパネルの動的リサイズに対応。マウス操作によるリサイズやサイズ制約の管理も行います。

これらの変更により、柔軟かつカスタマイズ可能なスプリットビューインターフェースが実現し、アプリケーションの利便性が大きく向上しました。